### PR TITLE
Add NPC memory framework

### DIFF
--- a/src/ai/memory.rs
+++ b/src/ai/memory.rs
@@ -1,10 +1,81 @@
 use bevy::prelude::*;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use uuid::Uuid;
 
-/// Represents persistent memory for NPCs keyed by Entity id.
+use super::personality::PersonalityProfile;
+
+/// Entity, location or event a memory is about.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MemorySubject {
+    /// Memory about a specific player identified by UUID.
+    Player(Uuid),
+    /// Memory about a location in the world.
+    Location(String),
+    /// Any other event description.
+    Event(String),
+}
+
+/// Single memory entry with timestamp and perceived impact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryEntry {
+    pub timestamp: DateTime<Utc>,
+    pub subject: MemorySubject,
+    /// Free form details remembered by the NPC.
+    pub detail: String,
+    /// How strongly this memory influenced the NPC.
+    pub impact: f32,
+}
+
+/// Collection of memories for a single NPC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NPCMemory {
+    /// Events from roughly the last 24 hours of play.
+    pub short_term: Vec<MemoryEntry>,
+    /// Persistent memories kept for the life of the NPC.
+    pub long_term: Vec<MemoryEntry>,
+    /// Feelings toward players, locations or factions.
+    pub emotions: HashMap<String, f32>,
+    /// Basic personality traits influencing reactions.
+    pub personality: PersonalityProfile,
+}
+
+impl Default for NPCMemory {
+    fn default() -> Self {
+        Self {
+            short_term: Vec::new(),
+            long_term: Vec::new(),
+            emotions: HashMap::new(),
+            personality: PersonalityProfile::default(),
+        }
+    }
+}
+
+impl NPCMemory {
+    /// Remember a new event either in short or long term memory.
+    pub fn remember(&mut self, entry: MemoryEntry, long_term: bool) {
+        const MAX_SHORT: usize = 1000;
+        const MAX_LONG: usize = 1000;
+
+        if long_term {
+            self.long_term.push(entry);
+            if self.long_term.len() > MAX_LONG {
+                self.long_term.remove(0);
+            }
+        } else {
+            self.short_term.push(entry);
+            if self.short_term.len() > MAX_SHORT {
+                self.short_term.remove(0);
+            }
+        }
+    }
+}
+
+/// Global storage of memory per NPC entity.
 #[derive(Resource, Default)]
-pub struct NpcMemory {
-    pub memories: HashMap<Entity, Vec<String>>,
+pub struct NpcMemoryBank {
+    pub memories: HashMap<Entity, NPCMemory>,
 }
 
 /// Plugin handling NPC memory graph.
@@ -12,6 +83,6 @@ pub struct MemoryPlugin;
 
 impl Plugin for MemoryPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<NpcMemory>();
+        app.init_resource::<NpcMemoryBank>();
     }
 }

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -2,6 +2,7 @@ use bevy::prelude::*;
 
 pub mod language;
 pub mod memory;
+pub mod personality;
 pub mod npc_core;
 pub mod world_ai;
 

--- a/src/ai/personality.rs
+++ b/src/ai/personality.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+/// Describes basic personality traits influencing NPC reactions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersonalityProfile {
+    /// Willingness to face danger.
+    pub courage: f32,
+    /// Tendency to distrust others.
+    pub distrust: f32,
+    /// Openness and kindness towards strangers.
+    pub friendliness: f32,
+    /// Sense of pride driving actions.
+    pub pride: f32,
+}
+
+impl Default for PersonalityProfile {
+    fn default() -> Self {
+        Self {
+            courage: 0.5,
+            distrust: 0.5,
+            friendliness: 0.5,
+            pride: 0.5,
+        }
+    }
+}

--- a/src/ai/world_ai.rs
+++ b/src/ai/world_ai.rs
@@ -1,14 +1,26 @@
 use bevy::prelude::*;
+use super::memory::NpcMemoryBank;
+
+/// Global struct representing the world's overarching AI.
+#[derive(Resource, Default)]
+pub struct WorldConsciousness;
 
 /// Generates and updates world events and quests.
 pub struct WorldAiPlugin;
 
 impl Plugin for WorldAiPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, generate_world_events);
+        app.init_resource::<WorldConsciousness>();
+        app.add_systems(Update, world_consciousness_update);
     }
 }
-
-fn generate_world_events() {
-    // Placeholder for world AI logic
+fn world_consciousness_update(
+    memories: Res<NpcMemoryBank>,
+    mut _world: ResMut<WorldConsciousness>,
+) {
+    // Iterate over NPC memories and derive global events or quests.
+    for (_entity, npc_mem) in memories.memories.iter() {
+        let _ = npc_mem.short_term.len();
+        // More complex processing will be implemented here.
+    }
 }


### PR DESCRIPTION
## Summary
- implement structured `MemoryEntry` and `NPCMemory`
- add `PersonalityProfile` traits
- update global memory bank and `WorldAiPlugin`

## Testing
- `cargo check` *(fails: edition 2025 unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_6883f674d94c832cada6214e56ea45cf