### PR TITLE
Implement emergent SoulProfile system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aeonseed"
 version = "0.1.0"
-edition = "202"
+edition = "2021"
 description = "Open source AI-driven MMORPG prototype"
 keywords = ["MMORPG", "bevy", "ai", "game"]
 license = "AGPL-3.0"

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -5,6 +5,7 @@ pub mod memory;
 pub mod personality;
 pub mod npc_core;
 pub mod world_ai;
+pub mod progression;
 
 /// Root plugin bundling all AI systems.
 pub struct AiPlugin;
@@ -16,6 +17,7 @@ impl Plugin for AiPlugin {
             npc_core::NpcPlugin,
             memory::MemoryPlugin,
             language::LanguagePlugin,
+            progression::ProgressionPlugin,
         ));
     }
 }

--- a/src/ai/progression.rs
+++ b/src/ai/progression.rs
@@ -1,0 +1,66 @@
+use std::time::Duration;
+
+use bevy::prelude::*;
+
+use crate::game::soul::{EmergentArchetype, SoulAnalysisResult, SoulProfile, TraitType};
+
+/// Timer resource controlling how often soul profiles are analyzed.
+#[derive(Resource)]
+pub struct ProgressionTimer(pub Timer);
+
+impl Default for ProgressionTimer {
+    fn default() -> Self {
+        Self(Timer::new(Duration::from_secs(600), TimerMode::Repeating))
+    }
+}
+
+/// Plugin triggering soul progression analyses.
+pub struct ProgressionPlugin;
+
+impl Plugin for ProgressionPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ProgressionTimer>();
+        app.add_systems(Update, analyze_souls);
+    }
+}
+
+/// Evaluate traits and emit events to update archetypes.
+fn analyze_souls(
+    time: Res<Time>,
+    mut timer: ResMut<ProgressionTimer>,
+    query: Query<(Entity, &SoulProfile)>,
+    mut results: EventWriter<SoulAnalysisResult>,
+) {
+    timer.0.tick(time.delta());
+    if !timer.0.finished() {
+        return;
+    }
+
+    for (entity, profile) in query.iter() {
+        let mut dominant: Option<(TraitType, f32)> = None;
+        for (t, v) in profile.tendencies.iter() {
+            if let Some((_, max)) = dominant {
+                if *v > max {
+                    dominant = Some((*t, *v));
+                }
+            } else {
+                dominant = Some((*t, *v));
+            }
+        }
+
+        let new_archetype = match dominant.map(|p| p.0) {
+            Some(TraitType::Discovery) if profile.tags.contains(&"artifact".to_string()) => {
+                Some(EmergentArchetype::Cipherwalker)
+            }
+            Some(TraitType::Discovery) => Some(EmergentArchetype::Fluxwarden),
+            Some(TraitType::Combat) if profile.tags.contains(&"trauma".to_string()) => {
+                Some(EmergentArchetype::Ashborn)
+            }
+            Some(TraitType::Healing) => Some(EmergentArchetype::Bloomcaller),
+            _ => None,
+        };
+
+        results.send(SoulAnalysisResult { entity, new_archetype });
+    }
+}
+

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -4,6 +4,7 @@ pub mod classes;
 pub mod player;
 pub mod professions;
 pub mod quests;
+pub mod soul;
 
 pub struct GamePlugin;
 
@@ -14,6 +15,7 @@ impl Plugin for GamePlugin {
             classes::ClassesPlugin,
             professions::ProfessionsPlugin,
             quests::QuestPlugin,
+            soul::SoulPlugin,
         ));
     }
 }

--- a/src/game/player.rs
+++ b/src/game/player.rs
@@ -1,5 +1,7 @@
 use bevy::prelude::*;
 
+use super::soul::SoulProfile;
+
 #[derive(Component)]
 pub struct Player;
 
@@ -12,5 +14,5 @@ impl Plugin for PlayerPlugin {
 }
 
 fn spawn_player(mut commands: Commands) {
-    commands.spawn(Player);
+    commands.spawn((Player, SoulProfile::default()));
 }

--- a/src/game/soul.rs
+++ b/src/game/soul.rs
@@ -1,0 +1,79 @@
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Player behavior metrics determining emergent archetypes.
+#[derive(Debug, Clone, Serialize, Deserialize, Component)]
+pub struct SoulProfile {
+    /// Weight for each trait accumulated through actions.
+    pub tendencies: HashMap<TraitType, f32>,
+    /// Tags collected from notable events.
+    pub tags: Vec<String>,
+    /// Current archetype derived from dominant traits.
+    pub alignment: Option<EmergentArchetype>,
+}
+
+impl Default for SoulProfile {
+    fn default() -> Self {
+        Self {
+            tendencies: HashMap::new(),
+            tags: Vec::new(),
+            alignment: None,
+        }
+    }
+}
+
+/// Core behavioral categories used for progression analysis.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum TraitType {
+    Combat,
+    Diplomacy,
+    Healing,
+    Taming,
+    Discovery,
+    Corruption,
+    Resistance,
+}
+
+/// Archetypes that can manifest from behavior patterns.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum EmergentArchetype {
+    /// Wanderer between worlds focused on exploration.
+    Fluxwarden,
+    /// Warrior born from destruction and trauma.
+    Ashborn,
+    /// Master of lost technologies.
+    Cipherwalker,
+    /// Guardian of living ecosystems.
+    Bloomcaller,
+}
+
+/// Event emitted when a profile analysis suggests a new archetype.
+#[derive(Debug, Event)]
+pub struct SoulAnalysisResult {
+    pub entity: Entity,
+    pub new_archetype: Option<EmergentArchetype>,
+}
+
+/// Plugin for soul profile management.
+pub struct SoulPlugin;
+
+impl Plugin for SoulPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<SoulAnalysisResult>();
+        app.add_systems(Update, apply_soul_analysis);
+    }
+}
+
+/// Update profiles when analysis results are produced by the AI.
+fn apply_soul_analysis(
+    mut events: EventReader<SoulAnalysisResult>,
+    mut query: Query<&mut SoulProfile>,
+) {
+    for event in events.read() {
+        if let Ok(mut profile) = query.get_mut(event.entity) {
+            profile.alignment = event.new_archetype.clone();
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- fix Cargo edition so the project compiles
- introduce `SoulProfile` component to track behavioral traits
- add archetype detection with `EmergentArchetype`
- create AI progression system that analyzes player behavior
- integrate new `SoulPlugin` and `ProgressionPlugin`
- spawn players with a default `SoulProfile`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6883f7aa1f74832c82da31d314dcd3c7