### PR TITLE
Add Aeon Code meta puzzle framework

### DIFF
--- a/src/aeoncode/fragment.rs
+++ b/src/aeoncode/fragment.rs
@@ -1,0 +1,55 @@
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Medium through which a fragment manifests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FragmentMedium {
+    /// Visual glyphs or symbols embedded in objects.
+    Glyph,
+    /// Melodic or rhythmic patterns carrying meaning.
+    Songline,
+    /// Architectural formations hinting at code structure.
+    StructurePattern,
+    /// Fragments perceived in shared dreams.
+    DreamSequence,
+    /// Vision relayed through an NPC encounter.
+    NPCVision,
+}
+
+/// Rule describing how a fragment can be interpreted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InterpretationRule {
+    /// Short hint or symbolic association.
+    pub hint: String,
+}
+
+/// Single piece of the global Aeon Code.
+#[derive(Component, Debug, Clone, Serialize, Deserialize)]
+pub struct AeonFragment {
+    /// Unique identifier of the fragment.
+    pub id: Uuid,
+    /// Encrypted or obfuscated fragment data.
+    pub encoded_data: String,
+    /// Seed in which the fragment originated.
+    pub origin_seed: Uuid,
+    /// Representation medium of the fragment.
+    pub medium: FragmentMedium,
+    /// Rules guiding symbolic interpretation of the fragment.
+    pub interpretation_rules: Vec<InterpretationRule>,
+}
+
+impl AeonFragment {
+    /// Convenience constructor generating a random fragment bound to a seed.
+    pub fn random_for_seed(origin_seed: Uuid) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            encoded_data: format!("{:x}", rand::random::<u128>()),
+            origin_seed,
+            medium: FragmentMedium::Glyph,
+            interpretation_rules: vec![InterpretationRule {
+                hint: "resonance".to_string(),
+            }],
+        }
+    }
+}

--- a/src/aeoncode/interpreter.rs
+++ b/src/aeoncode/interpreter.rs
@@ -1,0 +1,23 @@
+use bevy::prelude::*;
+
+use super::fragment::AeonFragment;
+use super::matrix::AeonCodeMatrix;
+
+/// Apply interpretation rules to decode a fragment semantically.
+pub fn interpret_fragment(fragment: &AeonFragment) -> String {
+    let mut decoded = fragment.encoded_data.clone();
+    for rule in &fragment.interpretation_rules {
+        decoded.push_str(&format!("|{}", rule.hint));
+    }
+    decoded
+}
+
+/// System that updates the global code matrix when new fragments appear.
+pub fn update_matrix(
+    mut matrix: ResMut<AeonCodeMatrix>,
+    query: Query<&AeonFragment, Added<AeonFragment>>,
+) {
+    for frag in query.iter() {
+        matrix.insert(frag.clone());
+    }
+}

--- a/src/aeoncode/matrix.rs
+++ b/src/aeoncode/matrix.rs
@@ -1,0 +1,26 @@
+use std::collections::HashMap;
+
+use bevy::prelude::Resource;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::fragment::AeonFragment;
+
+/// Central structure tracking global Aeon Code reconstruction progress.
+#[derive(Debug, Default, Serialize, Deserialize, Resource)]
+pub struct AeonCodeMatrix {
+    /// All fragments currently known across seeds, keyed by fragment id.
+    pub current_known: HashMap<Uuid, AeonFragment>,
+    /// Percentage of how much of the code has been reconstructed.
+    pub reconstructed_level: f32,
+}
+
+impl AeonCodeMatrix {
+    /// Insert a newly discovered fragment and update reconstruction progress.
+    pub fn insert(&mut self, fragment: AeonFragment) {
+        self.current_known.insert(fragment.id, fragment);
+        let count = self.current_known.len() as f32;
+        // Rough estimation: assume 256 fragments needed for full code.
+        self.reconstructed_level = (count / 256.0).min(1.0);
+    }
+}

--- a/src/aeoncode/mod.rs
+++ b/src/aeoncode/mod.rs
@@ -1,0 +1,32 @@
+use bevy::prelude::*;
+
+pub mod fragment;
+pub mod interpreter;
+pub mod matrix;
+
+use fragment::AeonFragment;
+use interpreter::update_matrix;
+use matrix::AeonCodeMatrix;
+
+/// Plugin bundling Aeon Code systems.
+pub struct AeonCodePlugin;
+
+impl Plugin for AeonCodePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<AeonCodeMatrix>();
+        app.add_systems(Update, update_matrix);
+    }
+}
+
+/// Generate a fragment for seeds without one.
+pub fn spawn_fragments_for_seeds(
+    mut commands: Commands,
+    seeds: Query<(Entity, &crate::seednet::seed::Seed), Without<AeonFragment>>,
+) {
+    for (entity, seed) in seeds.iter() {
+        if rand::random::<f32>() < 0.2 {
+            let fragment = AeonFragment::random_for_seed(seed.id);
+            commands.entity(entity).insert(fragment);
+        }
+    }
+}

--- a/src/ai/aeoncode.rs
+++ b/src/ai/aeoncode.rs
@@ -1,0 +1,20 @@
+use bevy::prelude::*;
+use crate::aeoncode::{matrix::AeonCodeMatrix, spawn_fragments_for_seeds};
+
+/// AI plugin controlling appearance and tracking of Aeon Code fragments.
+pub struct AeonCodeAiPlugin;
+
+impl Plugin for AeonCodeAiPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, spawn_fragments_for_seeds);
+        app.add_systems(Update, monitor_global_progress);
+    }
+}
+
+/// Example system reacting to reconstructed level.
+fn monitor_global_progress(matrix: Res<AeonCodeMatrix>) {
+    if matrix.reconstructed_level >= 1.0 {
+        // Placeholder for world-changing event once the code is solved.
+        info!("The Aeon Code has been fully deciphered!");
+    }
+}

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -7,6 +7,7 @@ pub mod npc_core;
 pub mod world_ai;
 pub mod progression;
 pub mod influence;
+pub mod aeoncode;
 
 /// Root plugin bundling all AI systems.
 pub struct AiPlugin;
@@ -20,6 +21,7 @@ impl Plugin for AiPlugin {
             language::LanguagePlugin,
             progression::ProgressionPlugin,
             influence::InfluencePlugin,
+            aeoncode::AeonCodeAiPlugin,
         ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use aeoncode::AeonCodePlugin;
 use ai::AiPlugin;
 use bevy::prelude::*;
 use game::GamePlugin;
@@ -12,6 +13,7 @@ fn main() {
             DefaultPlugins,
             SeedNetPlugin,
             AiPlugin,
+            AeonCodePlugin,
             GamePlugin,
             RenderPlugin,
             LocalizationPlugin,
@@ -19,6 +21,7 @@ fn main() {
         .run();
 }
 
+mod aeoncode;
 mod ai;
 mod game;
 mod localization;


### PR DESCRIPTION
## Summary
- implement Aeon Code system with fragments and reconstruction matrix
- add systems to spawn and track fragments
- integrate Aeon Code AI plugin and expose plugin in main

## Testing
- `cargo build`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_6883fc8eca64832c8f5032c9d3ec1e5f