### PR TITLE
Implement localization foundations

### DIFF
--- a/src/localization/auto_translate.rs
+++ b/src/localization/auto_translate.rs
@@ -1,1 +1,0 @@
-// Placeholder for automatic translation utilities

--- a/src/localization/mod.rs
+++ b/src/localization/mod.rs
@@ -1,12 +1,15 @@
 use bevy::prelude::*;
 
-pub mod auto_translate;
+pub mod translator;
 pub mod voice;
+pub mod registry;
 
+/// Plugin registering localization resources.
 pub struct LocalizationPlugin;
 
 impl Plugin for LocalizationPlugin {
-    fn build(&self, _app: &mut App) {
-        // Localization setup goes here
+    fn build(&self, app: &mut App) {
+        app.init_resource::<registry::LocalizationRegistry>()
+            .init_resource::<registry::ActivePlayerLanguage>();
     }
 }

--- a/src/localization/registry.rs
+++ b/src/localization/registry.rs
@@ -1,0 +1,27 @@
+use std::collections::HashMap;
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use super::translator::{LocalizedDialogue, PlayerLanguageProfile, TranslatedLine};
+
+/// Stores all loaded dialogues and allows runtime overrides by mods.
+#[derive(Resource, Default, Debug, Serialize, Deserialize)]
+pub struct LocalizationRegistry {
+    dialogues: HashMap<String, LocalizedDialogue>,
+}
+
+impl LocalizationRegistry {
+    /// Insert or override a dialogue entry.
+    pub fn insert<S: Into<String>>(&mut self, id: S, dialogue: LocalizedDialogue) {
+        self.dialogues.insert(id.into(), dialogue);
+    }
+
+    /// Fetch a translation for a specific dialogue id and language.
+    pub fn get(&self, id: &str, lang: &str) -> Option<&TranslatedLine> {
+        self.dialogues.get(id).and_then(|d| d.get(lang))
+    }
+}
+
+/// Resource with the current player's language settings.
+#[derive(Resource, Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ActivePlayerLanguage(pub PlayerLanguageProfile);

--- a/src/localization/translator.rs
+++ b/src/localization/translator.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+
+/// Represents a single line of translated text and optional metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranslatedLine {
+    /// Translated text content
+    pub text: String,
+    /// Optional ID for voice synthesis overrides
+    pub voice_id: Option<String>,
+    /// Cultural notes or hints for modders
+    pub cultural_note: Option<String>,
+}
+
+impl TranslatedLine {
+    pub fn new<T: Into<String>>(text: T) -> Self {
+        Self { text: text.into(), voice_id: None, cultural_note: None }
+    }
+}
+
+/// Holds the original dialogue and language specific variants.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LocalizedDialogue {
+    /// Source text as authored
+    pub original_text: String,
+    /// Map of language code -> translated line
+    pub language_variants: HashMap<String, TranslatedLine>,
+}
+
+impl LocalizedDialogue {
+    pub fn new<T: Into<String>>(text: T) -> Self {
+        Self { original_text: text.into(), language_variants: HashMap::new() }
+    }
+
+    /// Retrieve a translated line or fall back to English.
+    pub fn get(&self, lang: &str) -> Option<&TranslatedLine> {
+        self.language_variants
+            .get(lang)
+            .or_else(|| self.language_variants.get("en"))
+    }
+}
+
+/// Basic player language preferences detected at runtime.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PlayerLanguageProfile {
+    pub language_code: String,
+    pub prefers_voice: bool,
+    pub region_influences: Vec<String>,
+}
+
+/// Naive placeholder translator that simply echoes the input.
+pub fn translate_line(text: &str, target: &str) -> TranslatedLine {
+    // In a real system this would call an external AI service. The service
+    // would analyse idioms, style and cultural references before producing a
+    // translation. Here we simply mark the line with the requested language.
+
+    // TODO: plug in real translation backend (e.g. OpenAI, DeepL, LibreTranslate)
+    TranslatedLine::new(format!("[{}] {}", target, text))
+}

--- a/src/localization/voice.rs
+++ b/src/localization/voice.rs
@@ -1,1 +1,32 @@
-// Placeholder for voice processing and text-to-speech
+use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+
+/// Voice cloning profile describing how an NPC should sound.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VoiceCloneProfile {
+    /// Base timbre or reference voice used for cloning
+    pub base_voice: String,
+    /// Emotional tone that influences synthesis
+    pub emotional_tone: String,
+    /// Optional per-language voice overrides (TTS system specific IDs)
+    pub language_overrides: HashMap<String, String>,
+}
+
+impl VoiceCloneProfile {
+    pub fn new<T: Into<String>>(base: T, tone: T) -> Self {
+        Self { base_voice: base.into(), emotional_tone: tone.into(), language_overrides: HashMap::new() }
+    }
+
+    /// Returns the appropriate voice id for a given language if available
+    pub fn voice_for(&self, lang: &str) -> &str {
+        self.language_overrides
+            .get(lang)
+            .map(String::as_str)
+            .unwrap_or(&self.base_voice)
+    }
+}
+
+/// Placeholder TTS function. In production this would stream audio data.
+pub fn synthesize_to_audio(_line: &str, _profile: &VoiceCloneProfile) {
+    // Implementation would call into a TTS pipeline (e.g. Whisper+Bark)
+}


### PR DESCRIPTION
## Summary
- add base `Translator` with translation structs
- define `VoiceCloneProfile` for NPC voices
- implement `LocalizationRegistry` and plugin

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6883ff7cb9b0832c84372faa9a8e21c4