### PR TITLE
Document feature roadmap and add stubs

### DIFF
--- a/configs/default.toml
+++ b/configs/default.toml
@@ -1,0 +1,8 @@
+# Beispielkonfiguration fuer AeonSeed
+[network]
+seed_name = "example-seed"
+port = 7777
+
+[database]
+mongodb_url = "mongodb://localhost:27017"
+redis_url = "redis://localhost:6379"

--- a/crates/aeonseed-core/src/ai/reputation.rs
+++ b/crates/aeonseed-core/src/ai/reputation.rs
@@ -1,0 +1,19 @@
+//! KI-gestuetztes Rufsystem zwischen Spielern und NPCs.
+//! Noch nicht implementiert.
+use bevy::prelude::*;
+
+/// Speichert den aktuellen Rufwert.
+#[derive(Resource, Default)]
+pub struct ReputationScore {
+    pub value: i32,
+}
+
+/// Plugin zur Integration in die AI-Pipeline.
+pub struct ReputationAiPlugin;
+
+impl Plugin for ReputationAiPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ReputationScore>();
+        // TODO: Anbindung an NPC-Persoenlichkeit
+    }
+}

--- a/crates/aeonseed-core/src/features/guilds.rs
+++ b/crates/aeonseed-core/src/features/guilds.rs
@@ -1,0 +1,19 @@
+//! Grundlegende Guild-Funktionen.
+//! Spaeter koennen hier Rangsystem und Gildenquests implementiert werden.
+use bevy::prelude::*;
+
+/// Aktive Gildenliste.
+#[derive(Resource, Default)]
+pub struct GuildRegistry {
+    pub names: Vec<String>, // TODO: Persistenz in MongoDB
+}
+
+/// Plugin zum Laden des Guild-Systems.
+pub struct GuildsPlugin;
+
+impl Plugin for GuildsPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<GuildRegistry>();
+        // TODO: Befehle und Systeme anlegen
+    }
+}

--- a/crates/aeonseed-core/src/seeds/fusion.rs
+++ b/crates/aeonseed-core/src/seeds/fusion.rs
@@ -1,0 +1,19 @@
+//! Seed-Fusion verbindet zwei bestehende Seeds zu einer neuen Welt.
+//! Dies ist nur ein Stub und dient als Platzhalter fuer spaetere Implementierung.
+use bevy::prelude::*;
+
+/// Ressourcenhalter fuer anstehende Fusionsprozesse.
+#[derive(Resource, Default)]
+pub struct FusionQueue {
+    pub pending: Vec<String>, // TODO: Seed-IDs speichern
+}
+
+/// Plugin zur Registrierung der Seed-Fusion.
+pub struct SeedFusionPlugin;
+
+impl Plugin for SeedFusionPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<FusionQueue>();
+        // TODO: Systems zur Durchfuehrung der Fusion hinzufuegen
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,12 @@
+# Architekturuebersicht
+
+AeonSeed besteht aus mehreren Crates. Die wichtigsten Systeme fuer die neuen Features sind in `aeonseed-core` untergebracht.
+
+- **Seeds (`src/seeds/`)** verwalten serverbezogene Logik. Die geplante `fusion.rs` Datei erweitert dieses Modul um Seed-Fusion.
+- **Features (`src/features/`)** wird fuer Gameplay-Erweiterungen wie Gilden genutzt.
+- **KI (`src/ai/`)** enthaelt Kernsysteme wie `npc_core` und zukuenftig `reputation.rs` fuer ein Rufsystem.
+- **Expansions (`src/expansions/`)** bieten optionale Plugins (z.B. `seed_fusion`).
+
+Die Server kommunizieren ueber MongoDB und Redis, definiert in `infra/`. Bevy sorgt fuer das ECS und Rendering. Neue Komponenten sollten als Plugins implementiert werden, damit sie modular aktivierbar bleiben.
+
+Weitere Details finden sich in `docs/FEATURES_100.md` und der `ROADMAP.md`.

--- a/docs/FEATURES_100.md
+++ b/docs/FEATURES_100.md
@@ -1,0 +1,124 @@
+# 100 Erweiterungen
+
+Diese Liste fasst die geplanten Features von AeonSeed in thematische Bereiche zusammen. Die Nummerierung dient der einfachen Zuordnung innerhalb der Roadmap.
+
+## Gameplay
+1. Kooperative PvE-Quests mit dynamischem Schwierigkeitsgrad
+2. Prozedurale Dungeons auf Basis des Seeds
+3. Großangelegte Raidinstanzen für 40 Spieler
+4. Kompetitive PvP-Arenen
+5. Spielergeführte Gilden mit Rangsystem
+6. Weltweite Fraktionen beeinflussen Events
+7. Offene PvP-Zonen
+8. Belagerungen von Gildenfestungen
+9. Arenaranglisten mit Saisons
+10. Welt-Events durch Spieleraktionen
+
+## Welt & Umgebung
+11. Unterschiedliche Biome mit eigenen Ressourcen
+12. Zonen reagieren auf Umweltverschmutzung
+13. Dynamisches Wetter je Seed
+14. Ausbaubare Städte mit Spielerwohnungen
+15. Jahreszeitliche Events verändern die Welt
+16. Klimawandel zwischen Biomen
+17. Katastrophenereignisse wie Erdbeben
+18. Reisende Karawanen zwischen Städten
+19. Weltbosse wandern durch Zonen
+20. Versteckte Gebiete durch Erkundung
+
+## Wirtschaft
+21. Handwerksberufe mit Fortschritt
+22. Spieler-Marktplatz mit Auktionen
+23. Handelssystem mit sicherem Austausch
+24. Regionale Steuersätze beeinflussen Preise
+25. NPC-Wirtschaft reagiert auf Angebot & Nachfrage
+26. Rohstoffberufe wie Bergbau
+27. Qualitätsstufen bei hergestellten Items
+28. Lager- und Banksystem
+29. Spielershops in Städten
+30. Handelsrouten mit Gewinnboni
+
+## KI-Systeme
+31. Seed-KI generiert Quests
+32. Balancing-System passt Gegner an
+33. NPC-Persönlichkeiten mit Gedächtnis
+34. Prozedurale Quest-KI
+35. Seed-Evolution verändert Landschaften
+36. Dialog-KI für verzweigte Gespräche
+37. Dynamische Schwierigkeitsanpassung
+38. KI-gesteuerte Weltereignisse
+39. Beziehungen zwischen NPCs
+40. Fraktions-KI kontrolliert Gebiete
+
+## Dev-Tools
+41. Hot-reloadbare Entwicklungswerkzeuge
+42. Cluster-Profiler zur Performanceanalyse
+43. Wasm-Export für Web-Builds
+44. Sandbox-Plugin-Schnittstelle
+45. Skriptbare KI-Testumgebung
+46. Live-Metrik-Dashboard
+47. Seed-Debug-Konsole
+48. Simulierte Spielerbots
+49. Replay-System für Debugging
+50. Datenvisualisierungs-Tools
+
+## Barrierefreiheit & UI
+51. Komplette Controller- und Tastaturbelegung
+52. Anpassbare UI-Layouts
+53. Touch-Support für Mobile
+54. Interaktives Tutorial-System
+55. Farbblindoptionen
+56. Screenreader-Kompatibilität
+57. Großer Schriftmodus
+58. Audiohinweise bei wichtigen Ereignissen
+59. Vereinfachter Kampfmodus
+60. Ingame-Hilfe-Overlay
+
+## Build & Deployment
+61. Kommandozeilen-Build-Tools
+62. CI/CD-Pipeline
+63. Automatischer Client-Updater
+64. Benchmark-Suite
+65. Umfangreiche Tests
+66. Containerisierte Serverbereitstellung
+67. Statische Code-Analyse
+68. Plattformübergreifende Build-Skripte
+69. Hot-Patching-System
+70. Crash-Reporting und Telemetrie
+
+## Rollenspiel & Lore
+71. Tiefes Ruf- und Alignment-System
+72. Spielerbeziehungen und Heirat
+73. Seed-Wahl bei Charaktererstellung
+74. Epitaphe für gefallene Helden
+75. Umfangreiche Lore-Bücher
+76. Dynamische Handlungsstränge
+77. Persönliche Tagebücher
+78. Rollenspiel-Emotes
+79. Soziale Titel und Achievements
+80. Historiker-NPCs verweisen auf Vergangenheit
+
+## Community & Integration
+81. Ingame-Gildenkalender
+82. Discord-Bot für Serverevents
+83. Streaming-Overlay-Integration
+84. Öffentliche REST-API
+85. Seed-übergreifende Chatkanäle
+86. Von Spielern organisierte Turniere
+87. Community-Voting für Features
+88. Webbasierte Profilanzeige
+89. Freundesliste mit Benachrichtigungen
+90. Screenshot-Teilen in soziale Medien
+
+## Zukunftssysteme
+91. Seed-Fusion zum Verschmelzen von Welten
+92. Weltübergreifende Storylines
+93. Permadeath-Modus mit Memorialen
+94. Saisonale Resets mit Belohnungen
+95. Reisen zwischen Seeds über Portale
+96. Archivierung alter Seeds
+97. Prozedurale Weltgenerierung
+98. KI-kuratierte Events über alle Seeds
+99. Weltuntergangsszenarien
+100. Spielergetriebene Seed-Governance
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,25 @@
+# Roadmap
+
+Die folgenden Phasen skizzieren eine moegliche Reihenfolge fuer die Implementierung der 100 Features. Prioritaeten orientieren sich an Abhaengigkeiten zwischen den Systemen.
+
+## Phase 1 – Infrastruktur
+- **61–70 Build & Deployment:** Grundlegende Build-Tools und CI/CD aufsetzen.
+- **41–50 Dev-Tools:** Profiler und Hot-Reload foerdern schnelle Iterationen.
+- **51–60 Barrierefreiheit:** Fruhes Feedback zur Benutzerfuehrung.
+
+## Phase 2 – Welt und Wirtschaft
+- **11–20 Welt & Umgebung:** Biome und Zonen schaffen die Basis fuer Inhalte.
+- **21–30 Wirtschaft:** Handwerk und Handel beleben die Staedte.
+
+## Phase 3 – Gameplay-Kern
+- **1–10 Gameplay:** PvE, PvP und Gilden bilden das Herzstueck.
+- **31–40 KI-Systeme:** Seed-KI und Balancing verknuepfen alle Mechaniken.
+
+## Phase 4 – Community und Rollenspiel
+- **71–80 Rollenspiel & Lore:** Beziehungen und Lore vertiefen die Welt.
+- **81–90 Community & Integration:** Schnittstellen fuer externe Dienste.
+
+## Phase 5 – Zukunftssysteme
+- **91–100 Zukunftssysteme:** Seed-Fusion, Saisons und Permadeath erweitern die Lebensspanne des Spiels.
+
+Jede Phase enthaelt iterativ testbare Meilensteine. Details zu einzelnen Tasks finden sich in `docs/FEATURES_100.md`.

--- a/docs/SEED_ARCHIVE.md
+++ b/docs/SEED_ARCHIVE.md
@@ -1,0 +1,9 @@
+# Seed-Archive
+
+Historische Seeds koennen archiviert werden, um spaeter wieder bespielt oder ausgewertet zu werden. Dieser Mechanismus wird vor allem fuer saisonale Welten genutzt.
+
+1. Beim Ende einer Saison wird der Weltzustand als Snapshot gesichert.
+2. Alte Seeds koennen offline analysiert und wiederhergestellt werden.
+3. Spielerkoennen vergangene Heldentaten nachlesen.
+
+Weitere Details folgen im finalen Design.

--- a/examples/seed_config.toml
+++ b/examples/seed_config.toml
@@ -1,0 +1,4 @@
+# Beispiel fuer eine Seed-spezifische Konfiguration
+name = "demo-seed"
+max_players = 200
+weather_seed = 42

--- a/scenarios/fusion_example.md
+++ b/scenarios/fusion_example.md
@@ -1,0 +1,6 @@
+# Beispiel-Szenario: Seed-Fusion
+
+1. Zwei Seeds namens "Alpha" und "Beta" existieren parallel.
+2. Die Community entscheidet sich per Voting fuer eine Fusion.
+3. Nach dem Update betritt der Spieler eine hybridisierte Welt mit Elementen beider Seeds.
+4. Neue Quests fuehren durch die verbundenen Gebiete.


### PR DESCRIPTION
## Summary
- document 100 proposed features
- outline roadmap and architecture links
- add stub modules for seed fusion, guilds and AI reputation
- provide example config and scenario
- add seed archive documentation

## Testing
- `cargo test --workspace --no-run` *(failed: missing `alsa.pc`)*

------
https://chatgpt.com/codex/tasks/task_e_688490adaf28832c82977057784b01fd